### PR TITLE
Add localization support to the Kloudless file picker.

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,6 @@
+{
+  "directory": "bower_components",
+  "scripts": {
+    "postinstall": "node ./node_modules/cldr-data-downloader/bin/download.js -i bower_components/cldr-data/index.json -o bower_components/cldr-data/"
+  }
+}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -76,6 +76,35 @@ module.exports = function(grunt) {
     },
     // Copy files.
     copy: {
+      // Copy localization files
+      localization: {
+        files: [{ // CLDR Data
+          // this is copying data from ALL of the cultures with CLDR data, but only the language files needed
+          // will be loaded by the browser.  It would be possible to filter this data (i.e. replace '**' with something
+          // like '@(en|es)', but copying all of the available cultures allows additional languages to be added
+          // without modifying the gruntfile (and also allows for the possibility of programatically adding cultures
+          // in the future)
+          src: [
+            path.join('supplemental', 'likelySubtags.json'),
+            path.join('main', '**', 'numbers.json'),
+            path.join('supplemental', 'numberingSystems.json'),
+            path.join('main', '**', 'ca-gregorian.json'),
+            path.join('main', '**', 'timeZoneNames.json'),
+            path.join('supplemental', 'timeData.json'),
+            path.join('supplemental', 'weekData.json')
+          ],
+          dest: path.join(TMP_PATH, 'localization', 'cldr-data/'),
+          cwd: path.join(DIR, 'bower_components', 'cldr-data'),
+          expand: true,
+          filter: 'isFile'
+        }, { // messages
+          src: path.join('*.json'),
+          cwd: path.join(DIR, 'src', 'explorer', 'localization', 'messages'),
+          dest: path.join(TMP_PATH, 'localization', 'messages'),
+          expand: true,
+          filter: 'isFile'
+        }]
+      },
       // Copy vendor files from Bower into temporary directory.
       vendor: {
         files: [{
@@ -130,6 +159,27 @@ module.exports = function(grunt) {
         }, {
           src: path.join(DIR, 'bower_components', 'momentjs', 'moment.js'),
           dest: path.join(TMP_PATH, 'js', 'vendor', 'moment.js')
+        }, {
+          src: [
+            'cldr.js',
+            path.join('cldr', 'event.js'),
+            path.join('cldr', 'supplemental.js')
+          ],
+          dest: path.join(TMP_PATH, 'js', 'vendor'),
+          cwd: path.join(DIR, 'bower_components', 'cldrjs', 'dist'),
+          expand: true,
+          filter: 'isFile'
+        }, {
+          src: [
+            'globalize.js',
+            path.join('globalize', 'number.js'),
+            path.join('globalize', 'date.js'),
+            path.join('globalize', 'message.js')
+          ],
+          dest: path.join(TMP_PATH, 'js', 'vendor'),
+          cwd: path.join(DIR, 'bower_components', 'globalize', 'dist'),
+          expand: true,
+          filter: 'isFile'
         }]
       },
       // Copy minified vendor files from Bower into temporary directory.
@@ -183,6 +233,27 @@ module.exports = function(grunt) {
         }, {
           src: path.join(DIR, 'bower_components', 'momentjs', 'min', 'moment.min.js'),
           dest: path.join(TMP_PATH, 'js', 'vendor', 'moment.js')
+        }, {
+          src: [
+            'cldr.js',
+            path.join('cldr', 'event.js'),
+            path.join('cldr', 'supplemental.js')
+          ],
+          dest: path.join(TMP_PATH, 'js', 'vendor'),
+          cwd: path.join(DIR, 'bower_components', 'cldrjs', 'dist'),
+          expand: true,
+          filter: 'isFile'
+        }, {
+          src: [
+            'globalize.js',
+            path.join('globalize', 'number.js'),
+            path.join('globalize', 'date.js'),
+            path.join('globalize', 'message.js')
+          ],
+          dest: path.join(TMP_PATH, 'js', 'vendor'),
+          cwd: path.join(DIR, 'bower_components', 'globalize', 'dist'),
+          expand: true,
+          filter: 'isFile'
         }]
       },
       // Copy library directory into temporary directory.
@@ -237,6 +308,16 @@ module.exports = function(grunt) {
           dest: path.join(EXPLORER_DEST, 'js'),
           expand: true,
           flatten: true,
+        }, {
+          cwd: path.join(TMP_PATH, 'localization'),
+          src: '**',
+          dest: path.join(EXPLORER_DEST, 'localization'),
+          expand: true
+        }, {
+          cwd: path.join(TMP_PATH, 'js', 'vendor', 'plupload', 'i18n'),
+          src: '**',
+          dest: path.join(EXPLORER_DEST, 'js', 'vendor', 'plupload', 'i18n'),
+          expand: true
         }]
       }
     },
@@ -347,6 +428,7 @@ module.exports = function(grunt) {
     'loader_css',
     'uglify:dev',
     'copy:app',
+    'copy:localization',
     'copy:deploy'
   ]);
 
@@ -364,6 +446,7 @@ module.exports = function(grunt) {
     'build',
     'copy:vendor',
     'copy:vendor_min',
+    'copy:localization',
     'copy:lib',
     'jade',
     'includes',

--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,9 @@
     "momentjs": "2.7.0",
     "almond": "0.2.9",
     "jquery-dropdown": "1.0.6",
-    "jquery-scrollstop": "1.1.0"
+    "jquery-scrollstop": "1.1.0",
+    "cldr-data": "29.0.0",
+    "globalize": "1.3.0"
   },
   "resolutions": {
     "jquery": "2.1.3"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "bower": "1.3.4",
 
     "csso-stylus": "0.0.3",
-    "jquery": "2.1.1"
+    "jquery": "2.1.1",
+    "cldr-data-downloader": "0.3.2"
   },
   "devDependencies": {
     "grunt-contrib-watch": "^0.6.1"

--- a/src/explorer/js/app.js
+++ b/src/explorer/js/app.js
@@ -8,7 +8,9 @@
       'jqueryui': 'vendor/jquery-ui',
       'moxie': 'vendor/plupload/moxie',
       'plupload': 'vendor/plupload/plupload.dev',
-      'pluploadui': 'vendor/plupload/jquery.ui.plupload/jquery.ui.plupload'
+      'pluploadui': 'vendor/plupload/jquery.ui.plupload/jquery.ui.plupload',
+      'cldr': 'vendor/cldr',
+      'globalize': 'vendor/globalize'
     },
     shim: {
       'vendor/jquery-cookie': {
@@ -50,13 +52,13 @@
   require(['jquery', 'vendor/knockout', 'vendor/sammy',
            'vendor/loglevel', 'vendor/moment',
            'config', 'storage', 'accounts', 'files', 'auth',
-           'models/search', 'util',
+           'models/search', 'util', 'localization',
            // Imports below don't need to be assigned to variables.
            'jqueryui', 'vendor/jquery-dropdown', 'vendor/jquery-scrollstop',
            'moxie', 'plupload', 'pluploadui', 'vendor/jquery.finderSelect',
            'iexd-transport'],
   function($, ko, sammy, logger, moment, config, storage, AccountManager,
-    FileManager, auth, Search, util) {
+    FileManager, auth, Search, util, localization) {
 
     // Initialise and configure.
     logger.setLevel(config.logLevel);
@@ -553,6 +555,10 @@
         error: ko.observable(''),
         loading: ko.observable(true),
 
+        localizedConfirmPopup: function(token, variables) {
+          return confirm(localization.formatAndWrapMessage(token, variables));
+        },
+
         logo_url: ko.observable(),
 
         // Accounts view model.
@@ -578,7 +584,7 @@
           }, self),
           // return friendly names by service
           friendly_name: function(service_name) {
-            return service_names[service_name];
+            return localization.formatAndWrapMessage('servicenames/' + service_name);
           },
           // Returns hash mapping a string service name to an array of account objects.
           by_service: ko.computed(function() {
@@ -606,7 +612,7 @@
 
             explorer.manager.addAccount(service, {
               on_confirm_with_iexd: function() {
-                explorer.view_model.addconfirm.serviceName = service_names[service];
+                explorer.view_model.addconfirm.serviceName = localization.formatAndWrapMessage('servicenames/' + service)
                 explorer.view_model.addconfirm.serviceLogo =
                   services().filter(function(s) {
                     return s.id === service;
@@ -716,7 +722,7 @@
           service_friendly: ko.computed(function() {
             var self = this();
             var name = self.service;
-            return service_names[name];
+            return localization.formatAndWrapMessage('servicenames/' + name);
           }, self.manager.active),
           // Compute current working directory.
           cwd: ko.computed(function() {
@@ -852,6 +858,16 @@
       config.user_data.subscribe(function(userData) {
         self.view_model.logo_url(userData.logo_url);
       });
+
+      var setLocale = function (locale) {
+        localization.setCurrentLocale(locale);
+      };
+
+      // update the locale when the config changes
+      config.locale.subscribe(setLocale);
+
+      // load the default locale
+      setLocale(config.locale());
 
       this.view_model.files.searchQuery.extend({
         rateLimit: {

--- a/src/explorer/js/config.js
+++ b/src/explorer/js/config.js
@@ -47,6 +47,7 @@
       upload_location_uri: ko.observable(get_query_variable('upload_location_uri')),
       create_folder: JSON.parse(get_query_variable('create_folder')),
       chunk_size: 5*1024*1024,
+      locale: ko.observable('en'),
 
       // b/w compatibility
       account_key: JSON.parse(get_query_variable('account_key')),

--- a/src/explorer/js/localization.js
+++ b/src/explorer/js/localization.js
@@ -1,0 +1,309 @@
+(function () {
+  /**
+   * Localization module that provides translation and localization services.
+   */
+  'use strict';
+
+  /**
+   * Dictionary of supported locales.  This object specifies which locales are supported before
+   * attempting to load the files.  Items in this dictionary should have the following format:
+   *   locale: {
+   *     id: the id of the locale (i.e. 'en-US')
+   *     messages: name of message file (in /localization/messages )
+   *     plUpload_i18n: path to plUpload i18n file (in lib/plupload/i18n)
+   *     dateTimeFormat: optional, override default date format when displaying date + time.  Uses
+   *                     globalize time format (i.e. 'MMMdhm' for 12 hour clock, 'MMMdHm' for 24 hour).  Defaults to MMMdHm
+   *   }
+   *
+   * The specific locales (i.e. 'en-US') and the parent language (i.e 'en') should have separate
+   * entries in this dictionary.  The parent language will be used as the default if the specific
+   * locale is not supported (i.e. 'en-??' will default to 'en')
+   *
+   * Example:
+   * 'es': {
+   *      id: 'es',
+   *      messages: 'es.json',
+   *      plUpload_i18n: 'es.js'
+   *    }
+   */
+  var supportedLocales = {
+    'en': {
+      id: 'en',
+      messages: 'en.json',
+      plUpload_i18n: 'en.js',
+      dateTimeFormat: 'MMMdhm' // special case default en to 12 hour clock
+    }
+  };
+
+  define([
+    'jquery',
+    'vendor/knockout',
+    'globalize',
+    'util',
+
+    // Globalize modules
+    'globalize/date',
+    'globalize/message',
+    'globalize/number'
+  ], function ($, ko, globalize, util) {
+
+    var TEST_WRAPPER = '#'; // used to wrap text when in the TEST locale i.e. "#This is a localized string#"
+    var WARNING_WRAPPER = "!!!"; // used to wrap messages keys with no translated text when using the TEST locale i.e. "!!!Missing translation!!!"
+    var CLDR_DATA_URL = util.getBaseUrl() + '/localization/cldr-data/';  // CLDR localization root folder
+    var LOCALIZATION_MESSAGES_URL = util.getBaseUrl() + '/localization/messages/'; // folder containing translated strings
+    var DEFAULT_LOCALE = 'en';
+    var DEFAULT_DATETIME_FORMAT = 'MMMdHm';
+
+    var currentLocale = ko.observable();
+    var isTestLocale = ko.observable(false);
+    var loadedLocales = {};
+    var isSupplementalCldrLoaded = false;
+
+    var locUtil = {
+      /**
+       * Returns the currently supported locales
+       */
+      getSupportedLocales: function() {
+        return supportedLocales;
+      },
+      /**
+       * Gets the supported locale that most closely matches the requested locale
+       * @param locale The locale desired
+       */
+      getEffectiveLocale: function(locale) {
+        // normalize the locale code
+        locale = (locale || DEFAULT_LOCALE).toLowerCase();
+        if (locale === 'test') {
+          // special case for the test locale.  Use 'en'
+          locale = 'en';
+        }
+        var effectiveLocale = this.getSupportedLocales()[locale];
+        if (!effectiveLocale) {
+          // no exact match, try the language code
+          var language = locale.split('-')[0]
+          effectiveLocale = this.getSupportedLocales()[language];
+        }
+
+        // return the detected locale if found, or return the default locale
+        // if no suitable locale is found
+        return effectiveLocale || this.getSupportedLocales()[DEFAULT_LOCALE];
+      },
+      /**
+       * Changes the current locale.  Loads the supplemental data and locale specific data if necessary
+       * @param locale New locale ('en-US', 'es-ES', etc...)
+       * @param [callback] Called when the locale is loaded
+       */
+      setCurrentLocale: function (locale, callback) {
+        callback = callback || function() {};
+
+        var effectiveLocale = this.getEffectiveLocale(locale);
+        isTestLocale(locale === 'TEST');
+
+        // load the plupload i18n script now.  Don't need to wait on this -- plupload will handle it
+        // append the timestamp on the end to force re-exectuion of the script
+        $.getScript(util.getBaseUrl() + '/js/vendor/plupload/i18n/' + effectiveLocale.plUpload_i18n + '?timestamp=' + Date.now());
+
+        if (loadedLocales[effectiveLocale.id]) {
+          // this locale has already been loaded
+          currentLocale(loadedLocales[effectiveLocale.id]);
+          return callback();
+        } else {
+          // load the necessary language files
+          var cldrBaseUrl = CLDR_DATA_URL + 'main/' + effectiveLocale.id + '/';
+
+          var deferreds = [
+            $.getJSON(cldrBaseUrl + 'ca-gregorian.json'),
+            $.getJSON(cldrBaseUrl + 'numbers.json'),
+            $.getJSON(cldrBaseUrl + 'timeZoneNames.json'),
+            $.getJSON(LOCALIZATION_MESSAGES_URL + effectiveLocale.id + '.json')
+          ];
+
+          if (!isSupplementalCldrLoaded) {
+            // if the supplemental data is not loaded yet, then load it now
+            deferreds.push($.getJSON(CLDR_DATA_URL + 'supplemental/likelySubtags.json'));
+            deferreds.push($.getJSON(CLDR_DATA_URL + 'supplemental/timeData.json'));
+            deferreds.push($.getJSON(CLDR_DATA_URL + 'supplemental/weekData.json'));
+
+            // ok to mark the supplemental data as loaded even though it hasn't finished yet
+            isSupplementalCldrLoaded = true;
+          }
+
+          $.when.apply($, deferreds)
+            .done(function (gregorianDataStatusXhr, numbersDataStatusXhr, timeZoneNamesDataStatusXhr, messagesDataStatusXhr,
+                            likelySubtagsDataStatusXhr, timeDataDataStatusXhr, weekDataDataStatusXhr) {
+              if (likelySubtagsDataStatusXhr) {
+                globalize.load(likelySubtagsDataStatusXhr[0]);
+              }
+              if (timeDataDataStatusXhr) {
+                globalize.load(timeDataDataStatusXhr[0]);
+              }
+              if (weekDataDataStatusXhr) {
+                globalize.load(weekDataDataStatusXhr[0]);
+              }
+              globalize.load(gregorianDataStatusXhr[0], numbersDataStatusXhr[0], timeZoneNamesDataStatusXhr[0]);
+              globalize.loadMessages(messagesDataStatusXhr[0]);
+              var globalizeLocaleObject = globalize(effectiveLocale.id);
+              loadedLocales[effectiveLocale.id] = {
+                globalize: globalizeLocaleObject,
+                locale: effectiveLocale
+              };
+              currentLocale(loadedLocales[effectiveLocale.id]);
+              return callback();
+            });
+        }
+      },
+      /**
+       * Returns the currently selected locale
+       */
+      getCurrentLocale: function () {
+        return currentLocale();
+      },
+      /**
+       * Translates the given message into the current locale
+       * @param message Message key defined in /localization/*.json
+       * @param [variables] Optional. Extra variables for the localization tokens
+       * @returns {string} Translated text
+       */
+      formatMessage: function (message, variables) {
+        if (this.getCurrentLocale()) {
+          try {
+            return this.getCurrentLocale().globalize.formatMessage(message, variables);
+          } catch (e) {
+            if (isTestLocale()) {
+              // if this is the test locale, and no translation was found, then wrap it in a warning to make it more obvious
+              return WARNING_WRAPPER + message + WARNING_WRAPPER;
+            }
+          }
+        }
+        return message; // if no messages are found, return the token itself
+      },
+      /**
+       * Formats the given date for the current locale
+       * @param d Date to format
+       */
+      formatDateTime: function (d) {
+        var format = (this.getCurrentLocale() && locUtil.getCurrentLocale().locale.dateTimeFormat) ?
+          locUtil.getCurrentLocale().locale.dateTimeFormat : DEFAULT_DATETIME_FORMAT;
+        return this.getCurrentLocale().globalize.dateFormatter({skeleton: format})(d);
+      },
+      /**
+       * Formats the given number for the current locale
+       * @param n Number to format
+       */
+      formatNumber: function(n) {
+        return ((typeof n) === 'number') ? this.getCurrentLocale().globalize.formatNumber(n) : n;
+      },
+      /**
+       * Handles wrapping text with the test wrapper if the test locale is enabled, so that untranslated tokens within
+       * the page are more noticable.  Only HTML properties that are safe to change, such as the 'title', 'placeholder', 'html', and
+       * 'value', are changed.  Unsafe values, such as an image 'src' property are not changed
+       * @param translatedText Previously translated text
+       * @param [propertyName] Optional. The HTML property being localized
+       *
+       * @returns {string} Returns the unmodified translatedText property if the test locale is disabled or if the
+       * propertyName can't be changed safely.
+       */
+      wrapTestLocale: function (translatedText, propertyName) {
+        var textWrapper = '';
+        if (isTestLocale()) {
+          // some properties, such as urls, won't work with the text wrapper.
+          if (propertyName == null || ['title', 'placeholder', 'html', 'value'].indexOf(propertyName) >= 0) {
+            textWrapper = TEST_WRAPPER;
+          }
+        }
+
+        return textWrapper + translatedText + textWrapper;
+      },
+      /**
+       * Translates and wraps the text (if necessary).  Also formats number/date variables to the current locale
+       * @param message Message key defined in /localization/*.json
+       * @param [variables] Optional. Extra variables for the localization tokens
+       * @param [propertyName] Optional. The HTML property being localized
+       * @returns {string} Translated and wrapped text
+       */
+      formatAndWrapMessage: function (message, variables, propertyName) {
+        // format the variables if necessary
+        var formattedVariables = {};
+        if (variables) {
+          var self = this;
+          Object.keys(variables).forEach(function (key) {
+            var value = variables[key];
+            if ((typeof value) === 'number') {
+              formattedVariables[key] = self.formatAndWrapNumber(value, propertyName)
+            } else if (value instanceof Date) {
+              formattedVariables[key] = self.formatAndWrapDateTime(value, propertyName)
+            } else {
+              formattedVariables[key] = value;
+            }
+          });
+        }
+
+        return this.wrapTestLocale(this.formatMessage(message, formattedVariables), propertyName);
+      },
+      /**
+       * Formats the given date to the current locale and wraps the text (if necessary)
+       * @param d The Date to format
+       * @param [propertyName] Optional. The HTML property being localized
+       * @returns {*|string}
+       */
+      formatAndWrapDateTime: function(d, propertyName) {
+        return this.wrapTestLocale(this.formatDateTime(d), propertyName);
+      },
+      /**
+       * Formats the given number to the current locale and wraps the text (if necessary)
+       * @param n The number to format
+       * @param [propertyName] Optional. The HTML property being localized
+       */
+      formatAndWrapNumber: function(n, propertyName) {
+        return this.wrapTestLocale(this.formatNumber(n), propertyName);
+      }
+    };
+
+    /**
+     * Knockout.js Binding handler to translate HTML elements.
+     *
+     * Examples:
+     * simple example: translates the accounts/chooseaccount key:
+     * <span data-bind='translate: "accounts/chooseaccount"'>
+     *
+     * more complex example: translates the somekey key, specifying a variable used during the translation,
+     * and specifies that the translated text should go into the 'value' property:
+     * <input (data-bind='translate: {value: { message: "somekey", variables: { var1: somevariable }}}'>
+     */
+    ko.bindingHandlers.translate = {
+      'update': function (element, valueAccessor) {
+        var values = ko.utils.unwrapObservable(valueAccessor());
+        if (values && typeof values === 'object') {
+          Object.keys(values).forEach(function (property) {
+            var token = values[property] || {};
+            var translatedText = locUtil.formatAndWrapMessage(token.message, token.variables, property);
+            if (property === 'html') {
+              $(element).html(translatedText);
+            } else {
+              $(element).attr(property, translatedText);
+            }
+          });
+        } else {
+          // default to html property
+          $(element).html(locUtil.formatAndWrapMessage(values));
+        }
+      }
+    };
+
+    /**
+     * Knockout.js binding handler to translate dates in HTML elements.
+     *
+     * Example:
+     * <span data-bind='formatDate: created'>
+     */
+    ko.bindingHandlers.formatDate = {
+      'update': function (element, valueAccessor) {
+        var dateString = ko.utils.unwrapObservable(valueAccessor());
+        var localizedDateString = locUtil.formatAndWrapDateTime(new Date(dateString.substring(0, 19)));
+        $(element).html(localizedDateString);
+      }
+    };
+
+    return locUtil;
+  });
+})();

--- a/src/explorer/js/util.js
+++ b/src/explorer/js/util.js
@@ -20,6 +20,11 @@
     ieVersion = parseInt(nav.split('rv:')[1]);
   }
 
+  var roundFileSize = function(num) {
+    return Math.round(num*100)/100;
+  };
+
+
   define({
     /**
      * Generate random string suitable for use as a request ID
@@ -35,24 +40,49 @@
     isIE: isIE,
 
     /**
-      *Formats the sizes for files in the FileSystem
+      *Formats the sizes for files in the FileSystem.
       */
 
     formatSize: function(size){
+      var fileSize;
+      var unitOfMeasure;
         if (size === null || size === undefined || size === '')
-          return "";
+          return null;
         if (size < Math.pow(2,10)) {
-          size = size + " B";
+          fileSize = size;
+          unitOfMeasure = 'files/sizes/b';
         } else if (size < Math.pow(2,20)) {
-          size = +((size / Math.pow(2,10)).toFixed(2)) + " KB";
+          fileSize = roundFileSize(size / Math.pow(2,10));
+          unitOfMeasure = 'files/sizes/kb';
         } else if (size < Math.pow(2,30)) {
-          size = +((size / Math.pow(2,20)).toFixed(2)) + " MB";
+          fileSize = roundFileSize(size / Math.pow(2,20));
+          unitOfMeasure = 'files/sizes/mb';
         } else {
-          size = +((size / Math.pow(2,30)).toFixed(2)) + " GB";
+          fileSize = roundFileSize(size / Math.pow(2,30));
+          unitOfMeasure = 'files/sizes/gb';
         }
-        return size;
+
+        // map the result so that it can be used directly with the ko translate binding handler
+        return {
+          message: unitOfMeasure,
+          variables: {
+            fileSize: fileSize
+          }
+        };
       },
-  
+
+    /**
+     * Gets the base URL (one level above the js folder) for loading any scripts or JSON files
+     * figures out the base url based on the script tag for either app.js (dev) or explorer.js (production)
+     */
+    getBaseUrl: function() {
+      // get the app.js (for dev) or explorer.js (for production) script tag
+      var scriptUrl = $('script[src*=\'app.js\'], script[src*=\'explorer.js\']').first().attr('src').split('/');
+
+      // then remove the script file name and 'js' directory parts from the url and return the result
+      return scriptUrl.slice(0, scriptUrl.length-2).join('/'); // remove the script file name and 'js' directory parts from the url
+    },
+
     /**
      * Determines if the browser supports cross-domain requests via the normal
      * XMLHttpRequest object, or if we need to use the special IE-only

--- a/src/explorer/localization/messages/en.json
+++ b/src/explorer/localization/messages/en.json
@@ -1,0 +1,74 @@
+{
+  "en": {
+    "global": {
+      "select": "Select",
+      "cancel": "Cancel",
+      "save": "Save",
+      "upload": "Upload"
+    },
+    "files": {
+      "name": "Name",
+      "size": "Size",
+      "updated": "Updated",
+      "nofilesfound": "No Files Found",
+      "untitledfolder": "Untitled Folder",
+      "search": "Search",
+      "sizes": {
+        "b": "{fileSize} B",
+        "kb": "{fileSize} KB",
+        "mb": "{fileSize} MB",
+        "gb": "{fileSize} GB"
+      }
+    },
+    "accounts": {
+      "confirmRemove": "If you remove this account, you will no longer be able to explore. Are you sure?",
+      "connectedaccounts": "Connected accounts",
+      "logout": "logout",
+      "manage": "Manage your cloud storage accounts here.",
+      "chooseaccount": "Welcome! Please choose a service to connect",
+      "connectmore": "Connect more!",
+      "upload": "Upload",
+      "uploadfromcomputer": "Upload from your computer"
+    },
+    "selector": {
+      "mycomputer": "My Computer",
+      "accounts": "Accounts"
+    },
+    "servicenames": {
+      "cq5": "Adobe CQ5",
+      "dropbox": "Dropbox",
+      "gdrive": "Google Drive",
+      "box": "Box",
+      "evernote": "Evernote",
+      "skydrive": "OneDrive",
+      "sugarsync": "SugarSync",
+      "sharefile": "Citrix ShareFile",
+      "egnyte": "Egnyte",
+      "s3": "Amazon S3",
+      "sharepoint": "SharePoint Online",
+      "onedrivebiz": "OneDrive for Business",
+      "smb": "SMB",
+      "hubspot": "Hubspot Files",
+      "salesforce": "Salesforce Files",
+      "azure": "Azure Storage",
+      "cmis": "CMIS",
+      "alfresco": "Alfresco",
+      "alfresco_cloud": "Alfresco Cloud",
+      "jive": "Jive",
+      "webdav": "WebDAV",
+      "ftp": "FTP",
+      "computer": "My Computer"
+    },
+    "dropzone": {
+      "message": "Drag and drop files here, or click to open the File Explorer"
+    },
+    "computer": {
+      "nosupport": "Your browser doesn't have Flash, Silverlight or HTML5 support."
+    },
+    "addconfirm": {
+      "confirm": "Confirm account connection.",
+      "clickbelow": "Click below to connect your {serviceName} account",
+      "connectaccount": "Connect {serviceName} Account"
+    }
+  }
+}

--- a/src/explorer/templates/accounts.jade
+++ b/src/explorer/templates/accounts.jade
@@ -11,7 +11,7 @@
         // ko ifnot: logo_url
         img.klogo(src='https://s3-us-west-2.amazonaws.com/static-assets.kloudless.com/ext-assets/kloudless32x33.png')
         // /ko
-        span Manage your cloud storage accounts here.
+        span(data-bind='translate: "accounts/manage"') Manage your cloud storage accounts here.
       .nobackcontain(data-bind='if: accounts.all().length < 1')
         div.nobackbtn
         // ko if: logo_url
@@ -20,15 +20,15 @@
         // ko ifnot: logo_url
         img.klogo(src='https://s3-us-west-2.amazonaws.com/static-assets.kloudless.com/ext-assets/kloudless32x33.png')
         // /ko
-        span Welcome! Please choose a service to connect.
+        span(data-bind='translate: "accounts/chooseaccount"') Welcome! Please choose a service to connect.
     a.closeexplorer(data-bind='click: cancel')
 
 
   .containall
     .connectedaccounts(data-bind='with: accounts')
       div.header(data-bind='if: all().length > 0')
-        .intro-message Connected accounts
-        .logout-message(data-bind='click: logout') logout
+        .intro-message(data-bind='translate: "accounts/connectedaccounts"') Connected accounts
+        .logout-message(data-bind='click: logout, translate: "accounts/logout"') logout
         //- Linked accounts
         //- Each service group
         ul.linked-services
@@ -43,24 +43,24 @@
                     div
                       a(data-bind='click: $root.setLocation.bind($data, "#/files/" + account), text: account_name')
                     //-.unlink
-                    a.alert(data-bind='click: function (data, element) { if (!confirm("If you remove this account, you will no longer be able to explore. Are you sure?")) return false; $root.setLocation("#/account/disconnect/" + account) }')
+                    a.alert(data-bind='click: function (data, element) { if (!$root.localizedConfirmPopup("accounts/confirmRemove")) return false; $root.setLocation("#/account/disconnect/" + account) }')
                 //-.refresh(data-bind='if: !connected')
                 //-  a.button(data-bind='click: $root.setLocation.bind($data, "#/account/reconnect/" + account)') Refresh
             // ko if: $index() === ($parent.all().length - 1) && $parent.computer()
             li.linked-service
               div.servicename
                 img.servicelogo(data-bind='attr: {src: "https://s3-us-west-2.amazonaws.com/static-assets.kloudless.com/webapp/sources/computer.png"}')
-                span(data-bind='text: "Upload"')
+                span(data-bind='text: "Upload", translate: "accounts/upload"')
               div.accounts
                 ul.accountnames
                   li.account
                     div
-                      a(data-bind='click: $root.setLocation.bind($data, "#/computer"), text: "Upload from your computer"')
+                      a(data-bind='click: $root.setLocation.bind($data, "#/computer"), text: "Upload from your computer", translate: "accounts/uploadfromcomputer"')
             // /ko
 
       // ko if: $parent.services.length > 0
       .row(data-bind='if: all().length > 0')
-        div.intro-message.more Connect more!
+        div.intro-message.more(data-bind='translate: "accounts/connectmore"') Connect more!
       // /ko
 
     //- Add a new account.
@@ -72,5 +72,5 @@
             div.service
               img.servicelogo(data-bind='attr: {src: logo}')
               span.servicename-container
-                span.servicename(data-bind='text: name')
+                span.servicename(data-bind='text: $root.accounts.friendly_name(id)')
         // /ko

--- a/src/explorer/templates/addconfirm.jade
+++ b/src/explorer/templates/addconfirm.jade
@@ -11,10 +11,10 @@
         // ko ifnot: logo_url
         img.klogo(src='https://s3-us-west-2.amazonaws.com/static-assets.kloudless.com/ext-assets/kloudless32x33.png')
         // /ko
-        span Confirm account connection.
+        span(data-bind='translate: "addconfirm/confirm"') Confirm account connection.
 
   .addconfirminner
-    p.confirm Click below to connect your #[span(data-bind="text: addconfirm.serviceName")] account.
+    p.confirm(data-bind='translate: {html: { message: "addconfirm/clickbelow", variables: { serviceName: addconfirm.serviceName }}}') Click below to connect your #[span(data-bind="text: addconfirm.serviceName")] account.
     p.imageholder
       img(data-bind='attr: {src: addconfirm.serviceLogo}')
       img(src='https://s3-us-west-2.amazonaws.com/static-assets.kloudless.com/launch_site/support-plus.png')
@@ -25,8 +25,8 @@
       img(src='https://s3-us-west-2.amazonaws.com/static-assets.kloudless.com/static/kloudless_logomark.png', width=55, height=55)
       // /ko
     .buttonscontainer
-      a.button.reg(data-bind='click: $root.setLocation.bind($data, "#/")') Cancel
-      a.button.blue#confirm-add-button Connect #[span(data-bind="text: addconfirm.serviceName")] Account
+      a.button.reg(data-bind='click: $root.setLocation.bind($data, "#/"), translate: "global/cancel"') Cancel
+      a.button.blue#confirm-add-button(data-bind='translate: {html: { message: "addconfirm/connectaccount", variables: { serviceName: addconfirm.serviceName }}}') Connect #[span(data-bind="text: addconfirm.serviceName")] Account
 
   //- "Powered by Kloudless" footer
   footer

--- a/src/explorer/templates/computer.jade
+++ b/src/explorer/templates/computer.jade
@@ -5,7 +5,7 @@
 
     //- Current Upload View
     div#uploader
-      p Your browser doesn't have Flash, Silverlight or HTML5 support.
+      p(data-bind='translate: "computer/nosupport"') Your browser doesn't have Flash, Silverlight or HTML5 support.
 
     //- Footer buttons
     footer
@@ -15,8 +15,8 @@
           div.error-text(data-bind='text: error, attr: {title: error}')
           a.close(href='#')
         .buttonscontainer.right
-          a#cancel-button(href='javascript:void(0)').button.reg Cancel
-          a#upload-button.button.blue(href='javascript:void(0)') Upload
+          a#cancel-button(href='javascript:void(0)', data-bind='translate: "global/cancel"').button.reg Cancel
+          a#upload-button.button.blue(href='javascript:void(0)', data-bind='translate: "global/upload"') Upload
         div(data-bind='template: {name: "powered-by-kl-footer"}')
 
     //- Debug info, since we don't have proper UI elements

--- a/src/explorer/templates/dropzone.jade
+++ b/src/explorer/templates/dropzone.jade
@@ -1,3 +1,3 @@
 div#dropzone(style='background-color:#F5F6F7; color:#474747; width:100%; height:100%; text-align:center; cursor: pointer')
-  span(style='position:relative; top:33%') Drag and drop files here, or click to open the File Explorer
+  span(style='position:relative; top:33%', data-bind='translate: "dropzone/message"') Drag and drop files here, or click to open the File Explorer
 

--- a/src/explorer/templates/files.jade
+++ b/src/explorer/templates/files.jade
@@ -12,7 +12,7 @@
         // ko if: $root.flavor() == 'chooser'
         form.search-form(data-bind="submit: search")
           a#search-back-button(data-bind='click: refresh').search
-          input#search-query(type="text", placeholder="Search", data-bind="textInput: searchQuery").search
+          input#search-query(type="text", placeholder="Search", data-bind="textInput: searchQuery, translate: {placeholder: { message: \"files/search\" }}").search
           a#search-enable-button.search
         // /ko
 
@@ -64,13 +64,13 @@
     table(data-bind='with: files').clickable
       thead
         tr
-          th(data-bind='click: sort("name")') Name
+          th(data-bind='click: sort("name"), translate: "files/name"') Name
             .arrow-up#sort-name-up
             .arrow-down#sort-name-down
-          th(data-bind='click: sort("largest")') Size
+          th(data-bind='click: sort("largest"), translate: "files/size"') Size
             .arrow-up#sort-largest-up
             .arrow-down#sort-largest-down
-          th(data-bind='click: sort("recent")') Updated
+          th(data-bind='click: sort("recent"), translate: "files/updated"') Updated
             .arrow-up#sort-recent-up
             .arrow-down#sort-recent-down
     #fs-scroller.iewrapper
@@ -79,7 +79,7 @@
         tbody
           tr.info-row(align="center")
             td.info-cell
-              div No Files Found
+              div(data-bind='translate: "files/nofilesfound"') No Files Found
         // /ko
         // ko if: cwd().length > 0 && cwd()[0].type == "newfolder"
         tbody
@@ -88,7 +88,7 @@
               span()
                 div.foldericon()
               span()
-                input.new-folder-name(data-bind='attr: {value: "Untitled Folder"}')
+                input.new-folder-name(data-bind='attr: {value: "Untitled Folder"}, translate: {value: { message: "files/untitledfolder" }}')
               span(data-bind='click: mkdir')
                 span.save-button.inline-button Save
               span(data-bind='click: rmdir')
@@ -109,16 +109,21 @@
                 div.fileicon()
               span(data-bind='text: name')
 
-            td.size(data-bind='text: friendlySize')
+            // ko if: (friendlySize == null || friendlySize == "")
+            td.size
+            // /ko
+            // ko ifnot: (friendlySize == null || friendlySize == "")
+            td.size(data-bind='translate: { html: friendlySize }')
+            // /ko
 
             // ko if: (modified == null || modified == "") && created
-            td.updated(data-bind='text: moment(new Date(created.substring(0,19))).format("MMM DD   h:mm a")')
+            td.updated(data-bind='formatDate: created')
             // /ko
             // ko if: (modified == null || modified == "") && (created == null || created == "")
             td.updated
             // /ko
             // ko ifnot: modified == null || modified == ""
-            td.updated(data-bind='text: moment(new Date(modified.substring(0,19))).format("MMM DD   h:mm a")')
+            td.updated(data-bind='formatDate: modified')
             // /ko
           // /ko
           // ko if: type == "disabled"
@@ -127,7 +132,7 @@
               span
                 div.fileicon()
               span(data-bind='text: name')
-            td.updated(data-bind='text: moment(new Date(modified)).format("MMM DD   h:mm a")')
+            td.updated(data-bind='formatDate: modified')
           // /ko
           // /ko
 
@@ -142,12 +147,12 @@
         input.kloudless-saver-name(data-bind='value: files.all()[0].name')
         // /ko
         .buttonscontainer
-          a(data-bind='click: cancel').button.reg Cancel
+          a(data-bind='click: cancel, translate: "global/cancel"').button.reg Cancel
           // ko if: flavor() == 'chooser'
-          a(data-bind='click: confirm').button.blue Select
+          a(data-bind='click: confirm, translate: "global/select"').button.blue Select
           // /ko
           // ko if: flavor() == 'saver'
-          a(data-bind='click: save').button.blue Save
+          a(data-bind='click: save, translate: "global/save"').button.blue Save
           // /ko
         div(data-bind='template: {name: "powered-by-kl-footer"}')
 

--- a/src/explorer/templates/selector.jade
+++ b/src/explorer/templates/selector.jade
@@ -14,10 +14,10 @@
       // ko if: computer()
       li(data-bind='click: $root.setLocation.bind($data, "#/computer")')
         div.computericon
-        span My Computer
+        span(data-bind='translate: "selector/mycomputer"') My Computer
       // /ko
       // ko if: account_management()
       li(data-bind='click: $root.setLocation.bind($data, "#/accounts")')
         div.accountsicon
-        span Accounts
+        span(data-bind='translate: "selector/accounts"') Accounts
       // /ko


### PR DESCRIPTION
This PR adds localization support for the Kloudless file picker.  It uses knockout.js to dynamically localize elements on the page.  

There are a few things that this PR does not cover:

- There are no translations included with this PR, but we _might_ be able to provide some translations later (I'll get back to you in a couple of weeks).
- Right to left support.  Translations will still work, but the page will appear "backwards" in RTL languages
- Fixes to page styling affected by translations that are longer or shorter than the original English.  (For example, the plupload component on the "My Computer" account).  I didn't want to make any assumptions on how you wanted the pages styled.
- Language/Culture detection.  The changes here assume that the parent application knows which language that it wants to display.

Most of the localization happens in a couple of knockout binding handlers:
```
<span data-bind='translate: "accounts/chooseaccount"'>
<input (data-bind='translate: {value: { message: "somekey", variables: { var1: somevariable }}}'>
```
There is also a utility class that provides translation and localization functions:
```
localize.formatNumber(123.456); 
localize.formatDateTime(new Date());
localize.formatMessage(messageKey);
```

  The current locale is stored in an observable, so that changing the current locale immediately re-renders the page using the new culture.  The desired locale is specified using a new 'locale' config option, either when building the file picker or sending an update message to the file picker.  The default culture is 'en'.

```
window.Kloudless.explorer({
    app_id: window.app_id,
    multiselect: true,
    link: false,
    computer: true,
    services: ['all'],
    types: ['all'],
    display_backdrop: true,
    locale: 'en'
  });

window.chooser1.update({ locale: 'es' });  // file picker will immediately re-render in new culture
```
There is also a test culture that can be used to ensure that everything is localized and to find missing tokens.  To use it, specify 'TEST' as the locale.  It will wrap all localized elements in '#' (eg. "#I'm translated#") and will wrap any missing tokens with '!!!' (eg. "!!!missing translation!!!")

Adding a new language/culture requires the following:
- Add a file with translated tokens to localization/messages (i.e. es.json)
- Update the supportedLocales object in localization.js

Screenshots:
Files (English):
![english](https://user-images.githubusercontent.com/821291/29686400-cc6fd572-88e6-11e7-8c2f-ee8714411094.png)

Files (TEST):
![testculture](https://user-images.githubusercontent.com/821291/29686504-2fb95bb2-88e7-11e7-9827-ef0d34419d8b.png)

Account drop down (TEST):
![accountdropdown](https://user-images.githubusercontent.com/821291/29686531-4d0a8c40-88e7-11e7-8097-819335a97ce7.png)

Accounts (TEST):
![accounts](https://user-images.githubusercontent.com/821291/29686551-5bdad2ca-88e7-11e7-8534-e45963efa430.png)

Confirm account removal (TEST):
![confirm account removal](https://user-images.githubusercontent.com/821291/29686566-7155745c-88e7-11e7-9917-56e7ab558869.png)

A couple of examples of what a Spanish localization might look like.  These aren't professional translations and I did not include them with this PR, but I wanted to show what the date/number formatting and plupload translations would look like:

My Computer (Spanish): the file picker will switch the plupload component language, if it is supported by plupload:
![mycomputer](https://user-images.githubusercontent.com/821291/29686630-bb6954fa-88e7-11e7-807f-2abdc6a35cc5.png)

Files (Spanish): Demonstrates the number/date formatting changes based on the culture:
![spanish](https://user-images.githubusercontent.com/821291/29686687-f4ebeb20-88e7-11e7-9be9-96f265d6ebbd.png)






